### PR TITLE
Add default rule on object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,8 @@ export {
   partial,
 } from './builders';
 export { ShieldCache } from './rules';
-export { nexusShield, FieldShieldResolver } from './plugin';
+export {
+  nexusShield,
+  FieldShieldResolver,
+  ObjectTypeShieldResolver,
+} from './plugin';

--- a/tests/fixtures/schema.ts
+++ b/tests/fixtures/schema.ts
@@ -5,8 +5,12 @@ import { ruleType } from '../../src';
 
 export const Test = objectType({
   name: 'Test',
+  shield: ruleType({
+    resolve(_root, _args, _ctx) {
+      throw new AuthenticationError('OBJECT');
+    },
+  }),
   definition(t) {
-    t.id('id');
     t.string('publicProp', {
       shield: ruleType({
         resolve(_root, _args, _ctx) {
@@ -28,6 +32,7 @@ export const Test = objectType({
         },
       }),
     });
+    t.string('defaultProp');
   },
 });
 
@@ -38,10 +43,10 @@ export const QueryTest = extendType({
       type: Test,
       resolve(_root, _args, _ctx) {
         return {
-          id: 'BEEF',
           publicProp: 'public',
           privateProp: 'private',
           throwProp: 'throwProp',
+          defaultProp: 'defaultProp',
         };
       },
     });

--- a/tests/fixtures/server.ts
+++ b/tests/fixtures/server.ts
@@ -2,7 +2,12 @@ import { makeSchema } from '@nexus/schema';
 import { ApolloServer, ForbiddenError } from 'apollo-server';
 import * as path from 'path';
 
-import { allow, FieldShieldResolver, nexusShield } from '../../src';
+import {
+  allow,
+  FieldShieldResolver,
+  nexusShield,
+  ObjectTypeShieldResolver,
+} from '../../src';
 import * as types from './schema';
 
 declare global {
@@ -11,6 +16,10 @@ declare global {
     FieldName extends string
   > {
     shield?: FieldShieldResolver<TypeName, FieldName>;
+  }
+
+  interface NexusGenPluginTypeConfig<TypeName extends string> {
+    shield?: ObjectTypeShieldResolver<TypeName>;
   }
 }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -17,7 +17,6 @@ describe('Integration tests', () => {
     const query = gql`
       query {
         test {
-          id
           publicProp
         }
       }
@@ -25,14 +24,13 @@ describe('Integration tests', () => {
 
     const result = await client.query({ query });
 
-    expect(result.data).toEqual({ test: { id: 'BEEF', publicProp: 'public' } });
+    expect(result.data).toEqual({ test: { publicProp: 'public' } });
   });
 
   test('Server should return default error if not authorized', async () => {
     const query = gql`
       query {
         test {
-          id
           privateProp
         }
       }
@@ -47,7 +45,6 @@ describe('Integration tests', () => {
     const query = gql`
       query {
         test {
-          id
           throwProp
         }
       }
@@ -56,5 +53,19 @@ describe('Integration tests', () => {
     const result = await client.query({ query });
 
     expect(result.errors[0].message).toEqual('CUSTOM');
+  });
+
+  test('Server should use default object rule', async () => {
+    const query = gql`
+      query {
+        test {
+          defaultProp
+        }
+      }
+    `;
+
+    const result = await client.query({ query });
+
+    expect(result.errors[0].message).toEqual('OBJECT');
   });
 });


### PR DESCRIPTION
This adds a `shield` parameter to the `objectType` that will be used if no rule is specified for a field.