### PR TITLE
intialize shieldCtx when undefined

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -76,7 +76,12 @@ export const nexusShield = (settings: ShieldPluginSettings) => {
 
       return async (root, args, ctx, info, next) => {
         // Cache
-        const shieldCtx = ctx as ShieldContext;
+        const shieldCtx = (ctx ?? {
+          _shield: {
+            cache: {},
+          },
+        }) as ShieldContext;
+        
         if (!shieldCtx._shield) {
           shieldCtx._shield = {
             cache: {},


### PR DESCRIPTION
Hi.

I have created an [issue](https://github.com/Sytten/nexus-shield/issues/426) while ago and this is a pr about it.

In the plugin.ts file, shieldCtx was specified as **shieldContext**, but there was actually a case where the value of shieldCtx was undefined.

I fixed it as guided [here](https://github.com/Sytten/nexus-shield/issues/330), but the error didn't go away.
```
  const server = new ApolloServer({
    context: ({ req }) => {
      return { _shield: { cache: {} } }
    },
...
```

your fix will be of great help to me🙏